### PR TITLE
Added method chaining via AbstractMonad base class

### DIFF
--- a/src/AbstractMonad.php
+++ b/src/AbstractMonad.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Shrink0r\Monatic;
+
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+/**
+ * Wraps a given array, thereby providing recursive+fluent access to any underlying collections.
+ */
+abstract class AbstractMonad implements MonadInterface
+{
+    /**
+     * call an arbitrary method on the wrapped value
+     * and wrap the result again.
+     *
+     * @param string $name
+     * @param array $arguments
+     *
+     * @return MonadInterface
+     */
+    public function __call($name, array $arguments)
+    {
+        return $this->andThen(function($value) use ($name, $arguments) {
+            return static::wrap(
+                call_user_func([$value, $name], $arguments)
+            );
+        });
+    }
+}

--- a/src/Eventually.php
+++ b/src/Eventually.php
@@ -6,7 +6,7 @@ namespace Shrink0r\Monatic;
  * Wraps a given callable, which will eventually invoke a given success callback, when it can provide a value.
  * Basically this allows to chain async calls in a straight line, no callback nesting required.
  */
-class Eventually implements MonadInterface
+class Eventually extends AbstractMonad implements MonadInterface
 {
     /**
      * @var callable $codeBlock
@@ -103,5 +103,10 @@ class Eventually implements MonadInterface
     protected function run(callable $success = null)
     {
         call_user_func($this->codeBlock, $success);
+    }
+
+    public function __call($name, array $arguments)
+    {
+        return $this;
     }
 }

--- a/src/Many.php
+++ b/src/Many.php
@@ -7,7 +7,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 /**
  * Wraps a given array, thereby providing recursive+fluent access to any underlying collections.
  */
-class Many implements MonadInterface
+class Many extends AbstractMonad implements MonadInterface
 {
     /**
      * @var array $values
@@ -134,5 +134,23 @@ class Many implements MonadInterface
         }
 
         return array_merge($flattened, $unwrapped);
+    }
+
+    /**
+     * call an arbitrary method on the wrapped value
+     * and wrap the result again.
+     *
+     * @param string $name
+     * @param array $arguments
+     *
+     * @return MonadInterface
+     */
+    public function __call($name, array $arguments)
+    {
+        return $this->andThen(function($value) use ($name, $arguments) {
+            return static::wrap(
+                call_user_func([$value, $name], $arguments)
+            );
+        });
     }
 }

--- a/src/MonadInterface.php
+++ b/src/MonadInterface.php
@@ -37,4 +37,15 @@ interface MonadInterface
      * @return MonadInterface
      */
     public function andThen(callable $codeBlock);
+
+
+    /**
+     * call an arbitrary method on the wrapped value
+     *
+     * @param string $name
+     * @param array $arguments
+     *
+     * @return MonadInterface
+     */
+    public function __call($name, array $arguments);
 }

--- a/src/Option.php
+++ b/src/Option.php
@@ -7,7 +7,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 /**
  * Wraps a given value, thereby providing fluent access to it's underlying properties.
  */
-class Option implements MonadInterface
+class Option extends AbstractMonad implements MonadInterface
 {
     /**
      * @var mixed $value;

--- a/tests/unit/Fixtures/Article.php
+++ b/tests/unit/Fixtures/Article.php
@@ -8,10 +8,11 @@ class Article
 
     protected $text;
 
-    public function __construct($title, $text)
+    public function __construct($title, $text, array $tags = [])
     {
         $this->title = $title;
         $this->text = $text;
+        $this->tags = $tags;
     }
 
     public function getTitle()
@@ -22,5 +23,10 @@ class Article
     public function getText()
     {
         return $this->text;
+    }
+
+    public function getTags()
+    {
+        return $this->tags;
     }
 }

--- a/tests/unit/Fixtures/Category.php
+++ b/tests/unit/Fixtures/Category.php
@@ -23,4 +23,9 @@ class Category
     {
         return reset($this->articles) ?: null;
     }
+
+    public function getArticles()
+    {
+        return $this->articles;
+    }
 }

--- a/tests/unit/ManyTest.php
+++ b/tests/unit/ManyTest.php
@@ -4,6 +4,8 @@ namespace Shrink0r\Monatic\Tests;
 
 use Shrink0r\Monatic\Many;
 use Shrink0r\Monatic\Option;
+use Shrink0r\Monatic\Tests\Fixtures\Article;
+use Shrink0r\Monatic\Tests\Fixtures\Category;
 use PHPUnit_Framework_TestCase;
 
 class ManyTest extends PHPUnit_Framework_TestCase
@@ -102,5 +104,27 @@ class ManyTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals([], $titleWords->unwrap());
+    }
+
+    public function testCallChainValid()
+    {
+        $article1 = new Article('monads hurray 1', '', ['one', 'two']);
+        $article2 = new Article('monads hurray 2', '', ['foo', 'bar']);
+        $category = new Category('programming', [ $article1, $article2 ]);
+
+        $tags = Many::wrap($category)->getArticles()->getTags();
+
+        $this->assertEquals(['one', 'two', 'foo', 'bar'], $tags->unwrap());
+    }
+
+    public function testCallChainInvalid()
+    {
+        $article1 = new Article('monads hurray 1', '');
+        $article2 = new Article('monads hurray 2', '');
+        $category = new Category('programming', [ $article1, $article2 ]);
+
+        $tags = Many::wrap($category)->getArticles()->getTags();
+
+        $this->assertEquals([], $tags->unwrap());
     }
 }

--- a/tests/unit/OptionTest.php
+++ b/tests/unit/OptionTest.php
@@ -68,4 +68,23 @@ class OptionTest extends PHPUnit_Framework_TestCase
         $this->assertNull($title->unwrap());
         $this->assertInstanceOf(None::CLASS, $title);
     }
+
+    public function testCallChainValid()
+    {
+        $article = new Article('monads hurray', 'I can haz monads and so can haz you!');
+        $category = new Category('programming', [ $article ]);
+
+        $title = Option::wrap($category)->getFirstArticle()->getTitle();
+
+        $this->assertEquals($article->getTitle(), $title->unwrap());
+    }
+
+    public function testCallChainInvalid()
+    {
+        $category = new Category('programming', [ ]);
+
+        $title = Option::wrap($category)->getFirstArticle()->getTitle();
+
+        $this->assertInstanceOf(None::CLASS, $title);
+    }
 }


### PR DESCRIPTION
This enables calling methods on monads that are passed through to their wrapped values:

``` php
$monad->foo()->bar();
```
